### PR TITLE
Add support for `/group-order` URLs

### DIFF
--- a/service/rate.go
+++ b/service/rate.go
@@ -13,7 +13,7 @@ import (
 	"github.com/oriser/regroup"
 )
 
-var groupLinkRe = regroup.MustCompile(`\/group\/(?P<id>[A-Z0-9]+?)($|\/$)`)
+var groupLinkRe = regroup.MustCompile(`\/group(-order)?\/(?P<id>[A-Z0-9]+?)((\/join)?\/?$)`)
 
 var errWontJoin = errors.New("wont join because the channel is not accessible")
 var errNotInTime = errors.New("order not in tracking time")


### PR DESCRIPTION
Sometimes users send the `https://wolt.com/en/group-order/<ID>/join` URL, as opposed to `https://wolt.com/en/group/<ID>` .
The `/group` URL is the Wolt uses for link sharing, while the `/group-order` URL is the one the users are seeing once the link has been opened in the browser.