### PR TITLE
Support pre-order only venues during venue monitoring

### DIFF
--- a/service/rate.go
+++ b/service/rate.go
@@ -78,6 +78,10 @@ func (h *Service) HandleLinkMessage(req LinksRequest) (string, error) {
 			_, _ = h.informEvent(req.Channel, fmt.Sprintf("Order for group ID %s was canceled", groupID.ID), "", req.MessageID)
 			return "", nil
 		}
+		if strings.Contains(err.Error(), "context canceled while waiting") {
+			_, _ = h.informEvent(req.Channel, "Timed out waiting for order to be ready", "", req.MessageID)
+			return "", nil
+		}
 		log.Printf("Error getting rate for group %s: %v\n", groupID.ID, err)
 		_, _ = h.informEvent(req.Channel, fmt.Sprintf("I had an error getting rate for group ID %s", groupID.ID), "", req.MessageID)
 		return "", nil

--- a/wolt/venue.go
+++ b/wolt/venue.go
@@ -33,7 +33,11 @@ type Venue struct {
 			DateUnix int64 `json:"$date"`
 		} `json:"end"`
 	} `json:"offline_period"`
-	Online   bool   `json:"online"`
+	Online          bool `json:"online"`
+	PreorderEnabled bool `json:"preorder_enabled"`
+	PreorderTimes   struct {
+		Delivery map[string][]interface{} `json:"delivery"`
+	} `json:"preorder_times"`
 	City     string `json:"city"`
 	Timezone string `json:"timezone"`
 
@@ -152,4 +156,8 @@ func (v *Venue) CalculateDeliveryRate(source Coordinate) (int, error) {
 
 func (v *Venue) IsDelivering() bool {
 	return v.DeliverySpecs.DeliveryEnabled && v.Online && v.Alive != 0
+}
+
+func (v *Venue) IsOpenForPreorderDelivery() bool {
+	return v.PreorderEnabled && v.PreorderTimes.Delivery != nil
 }


### PR DESCRIPTION
This PR adds another state for the venue monitoring feature:

If the venue is closed for deliveries but is open for pre-order deliveries, Bolt will let the user know.
(Currently, the venue is treated as closed.)

Also, this PR fixes the message which Bolt sends when venue monitoring times out.