### PR TITLE
Update `Dockerfile` Go version to 1.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-buster as builder
+FROM golang:1.23-bookworm as builder
 WORKDIR /go/src/bolt
 COPY . .
 


### PR DESCRIPTION
Update `Dockerfile` Go version to 1.23 in order to match the change in https://github.com/oriser/Bolt/pull/25.